### PR TITLE
fix: sample and other opcodes in same line

### DIFF
--- a/src/sfz/opcodes/parse.rs
+++ b/src/sfz/opcodes/parse.rs
@@ -244,10 +244,9 @@ pub(crate) enum SfzToken {
     /// Opcodes and assigned opcode values are separated by the equal-to sign
     /// `=`, without spaces between the opcode and the sign.
     ///
-    /// All opcodes can be in the same line, separated by spaces, except for
-    /// **sample**, which must not have any other opcode after it in the same
-    /// line, in order to recognize filenames with spaces.
-    #[regex("sample=.+", Opcode::parse_opcode)]
+    /// All opcodes can be in the same line, separated by spaces.
+    /// **sample** uses a special regex to support filenames with spaces.
+    #[regex("sample=[^.]+\\.\\S+", Opcode::parse_opcode)]
     #[regex("[a-zA-Z0-9_]+=[\\w.]+", Opcode::parse_opcode)]
     Opcode(Opcode),
 
@@ -350,8 +349,7 @@ mod tests_token {
     fn test_sfz_simple() {
         let mut lex = SfzToken::lexer(
             "<region>
-sample=MOHorn_mute_A#1_v1_1.wav
-lokey=46 hikey=48
+sample=with space/MOHorn_mute_A#1_v1_1.wav lokey=46 hikey=48
 pitch_keycenter=46
 lovel=0 hivel=62
 volume=2.0",
@@ -363,7 +361,7 @@ volume=2.0",
         assert_eq!(
             lex.next(),
             Some(SfzToken::Opcode(Opcode::sample(PathBuf::from(
-                "MOHorn_mute_A#1_v1_1.wav"
+                "with space/MOHorn_mute_A#1_v1_1.wav"
             ))))
         );
         // recognize multiple opcodes in the same line


### PR DESCRIPTION
Hey @andamira, I'm currently writing a [sampler](https://github.com/soakyaudio/sampler) in Rust and while looking into SFZ support, I came across your awesome library. I ran into a problem with the `sample` opcode as its regex doesn't allow other opcodes in the same line ([example in my fav sfz samples](https://github.com/jlearman/jRhodes3d/blob/master/jRhodes3d/_jRhodes3d-st-flac.sfz)).

I saw #2 was dealing with a similar problem, but I want to propose a more versatile regex with this PR. It no longer parses the rest of the line, therefore other opcodes can follow `sample`. Spaces are still allowed in the path except for in the file extension (= after the last `.` character, but I don't think such extensions exist anyway).

Regex explanation:
```
opcode  separator  path (w. spaces)  extension dot  extension (until space)
|       |          |                 |              |
sample  =          [^.]+             \\.            \\S+
```

Thanks a ton for your work & have a nice day! :)