### PR TITLE
fix: f32 does not implement `Eq` trait

### DIFF
--- a/src/sfz/types.rs
+++ b/src/sfz/types.rs
@@ -22,7 +22,7 @@ pub const MAX_SAMPLE_RATE: f32 = 384_000.0;
 
 /// All the possible types allowed in an Opcode
 #[allow(non_camel_case_types)]
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum OpcodeType {
     i8(Option<i8>),
     u8(Option<u8>),


### PR DESCRIPTION
Fix for compilation error introduced in https://github.com/andamira/sofiza/commit/3ea276cfa4cc639746a97ff08054601ce88a7586.

![image](https://user-images.githubusercontent.com/8472721/193341811-8c8b8c73-c487-45a9-80af-9cf821fff0ba.png)
