### PR TITLE
Fix broken test

### DIFF
--- a/src/sfz/opcodes/parse.rs
+++ b/src/sfz/opcodes/parse.rs
@@ -386,6 +386,7 @@ volume=2.0",
 mod tests_parameters {
 
     use super::{Opcode, Regex};
+    use log::trace;
 
     #[test]
     fn test_parse_all_opcodes() {


### PR DESCRIPTION
While running `cargo test`, I encountered an error. It was due to a missing `log::trace`, so I added it. 
Of course, this does not affect the functionality.